### PR TITLE
feat: complexity heatmap mode for risk visualization

### DIFF
--- a/app/city.js
+++ b/app/city.js
@@ -20,6 +20,17 @@ const BUILDING_COLORS = [
   0xbfc9ce, // light grey
 ];
 
+// Blue-to-red gradient for risk heatmap (0.0 = low risk blue, 1.0 = high risk red)
+function riskColor(churn, bugCount, loc) {
+  const safeLoc = Math.max(loc || 1, 1);
+  const score = ((churn || 0) * (bugCount || 0)) / safeLoc;
+  const t = Math.min(score / 2, 1); // normalize — score of 2+ maps to max red
+  const r = Math.round(60 + t * 195);
+  const g = Math.round(60 + (1 - Math.abs(t - 0.5) * 2) * 100);
+  const b = Math.round(200 - t * 170);
+  return (r << 16) | (g << 8) | b;
+}
+
 export class City {
   constructor(scene, data) {
     this.scene = scene;
@@ -375,6 +386,26 @@ export class City {
         new THREE.Vector3(to.x, 0.2, to.z)
       );
       this.roadGroup.add(new THREE.Line(new THREE.BufferGeometry().setFromPoints(curve.getPoints(12)), mat));
+    }
+  }
+
+  setColorMode(mode) {
+    this.colorMode = mode;
+    const langColors = {
+      typescript: 0x6b9ac4, javascript: 0xe8c840, python: 0x5a8fa8,
+      rust: 0xc8855a, go: 0x5abfcf, java: 0xb07830,
+      ruby: 0xa85050, css: 0x9070b8, html: 0xd06030,
+      shell: 0x80b850, json: 0x60c088, markdown: 0x8090b0,
+    };
+    for (const b of this.buildings) {
+      const d = b.mesh.userData;
+      let color;
+      if (mode === 'heatmap') {
+        color = riskColor(d.churn, d.bug_count, d.loc);
+      } else {
+        color = langColors[d.language] || BUILDING_COLORS[Math.floor(Math.random() * BUILDING_COLORS.length)];
+      }
+      b.mesh.material.color.setHex(color);
     }
   }
 

--- a/app/controls.js
+++ b/app/controls.js
@@ -46,6 +46,7 @@ export class CityControls {
       <span class="stat"><strong>${this.data.stats?.contributors || 0}</strong> devs${starsText}</span>
     `;
     topBar.querySelector('.top-right').innerHTML = `
+      <button id="btn-toggle-heatmap" class="ctrl-btn" title="Toggle risk heatmap">🗺️</button>
       <button id="btn-toggle-fires" class="ctrl-btn" title="Toggle fires">🔥</button>
       <button id="btn-toggle-roads" class="ctrl-btn" title="Toggle roads">🛣️</button>
       <button id="btn-rocket" class="ctrl-btn" title="Launch rocket">🚀</button>
@@ -173,6 +174,11 @@ export class CityControls {
 
   // Expose for external button binding
   bindButtons(effects) {
+    this._heatmapOn = false;
+    document.getElementById('btn-toggle-heatmap')?.addEventListener('click', () => {
+      this._heatmapOn = !this._heatmapOn;
+      this.city.setColorMode(this._heatmapOn ? 'heatmap' : 'language');
+    });
     document.getElementById('btn-toggle-fires')?.addEventListener('click', () => {
       effects.group.visible = !effects.group.visible;
     });


### PR DESCRIPTION
## Summary
- Adds a risk heatmap color mode that encodes `churn * bug_count / loc` as a blue-to-red gradient on each building
- Adds a toggle button in the top-right toolbar to switch between language coloring and heatmap mode
- Uses existing userData metrics already attached to building meshes by the analyzer

## Test plan
- [ ] Load a codebase city and verify buildings are colored by language (default behavior unchanged)
- [ ] Click the heatmap toggle button and verify buildings recolor on a blue-to-red gradient
- [ ] Click again to verify it toggles back to language colors
- [ ] Hover over a high-risk (red) building and confirm tooltip shows high churn/bug values

Generated with [Claude Code](https://claude.com/claude-code)